### PR TITLE
[Finish] fix-cart-in

### DIFF
--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -22,7 +22,7 @@
               （税込）
             </div>
             <div class="row mt-4">
-              <%= f.select :amount, [1,2,3,4,5,6,7,8,9], { include_blank: '個数選択' }, class: "col-4 form-control" %>
+              <%= f.select :amount, [*1..10], {include_blank: '個数選択'},{required: true, class: "col-4 form-control"} %>
               <%= f.hidden_field :item_id, :value => @item.id %>
               <%= f.submit "カートに入れる", class: "col-4 offset-1 btn btn-success font-weight-bold" %>
             </div>


### PR DESCRIPTION
# cartに追加するときに選択なしのバリデーションチェック
（かっくん指摘ありがとう！）
* フォーム側でチェックできるように以下の変更を実施
変更前：<%= f.select :amount, [1,2,3,4,5,6,7,8,9], { include_blank: '個数選択' }, class: "col-4 form-control" %>
変更後：<%= f.select :amount, [*1..10], {include_blank: '個数選択'},{required: true, class: "col-4 form-control"} %>