### PR TITLE
Fix rayout

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -9,6 +9,7 @@ class Public::CartItemsController < ApplicationController
   def update
     cart_item = CartItem.find(params[:id])
     cart_item.update(amount: cart_item_params[:amount])
+    flash[:notice] = "カート個数を変更しました。"
     redirect_to cart_items_path
   end
 

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -19,8 +19,8 @@ class Public::OrdersController < ApplicationController
     when "2"
       # 選択チェック
       unless params[:address_id].present?
-        flash[:notice] = "住所を選択してください。"
-        redirect_to new_order_path
+        flash.now[:danger] = "住所を選択してください。"
+        render :new
       else
         address = Address.find(params[:address_id])
         @postal_code = address.postal_code
@@ -30,8 +30,8 @@ class Public::OrdersController < ApplicationController
     else
       # 入力チェック
       if params[:postal_code]=="" || params[:address]=="" || params[:name]==""
-        flash[:notice] = "お届け先郵便番号・住所・宛名を入力してください。"
-        redirect_to new_order_path
+        flash.now[:danger] = "お届け先郵便番号・住所・宛名を入力してください。"
+        render :new
       else
         @postal_code = params[:postal_code]
         @address = params[:address]

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,7 @@ class Item < ApplicationRecord
       file_path = Rails.root.join('app/assets/images/no_image.jpg')
       image.attach(io: File.open(file_path), filename: 'default-image.jpg', content_type: 'image/jpeg')
     end
-    image.variant(resize_to_limit: [width, height])
+    image.variant(resize_to_limit: [width, height]).processed
   end
 
   def with_tax_price

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,46 +1,50 @@
 <header>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="col-3">
-      <%= link_to root_path, class: 'nav-link nav-brand' do %>
-        <span>LOGO</span>
-      <% end %>
-    </div>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="col">
-      <div class="row">
-        <div class="collapse navbar-collapse justify-content-end" id="navbarNavDropdown">
-          <ul class="navbar-nav ml-5">
-            <% if customer_signed_in? %>
-              <!--Customer ログイン後header-->
-              <span class="navbar-text mr-4">ようこそ、<%= current_customer.full_name %>さん</span>
-              <li><%= link_to "マイページ", customers_path, class: 'nav-link' %></li>
-              <li><%= link_to "商品一覧", items_path, class: 'nav-link' %></li>
-              <li><%= link_to "カート", cart_items_path, class: 'nav-link' %></li>
-              <li><%= link_to "ログアウト", destroy_customer_session_path, class: 'nav-link', method: :delete %></li>
-            <% elsif admin_signed_in? %>
-              <!--Admin ログイン後header-->
-              <li><%= link_to "商品一覧", admin_items_path, class: 'nav-link' %></li>
-              <li><%= link_to "会員一覧", admin_customers_path, class: 'nav-link' %></li>
-              <li><%= link_to "注文履歴一覧", admin_path, class: 'nav-link' %></li>
-              <li><%= link_to "ジャンル一覧", admin_genres_path, class: 'nav-link'%></li>
-              <li><%= link_to "ログアウト", destroy_admin_session_path, class: 'nav-link', method: :delete %></li>
-            <% else %>
-              <!--共通ログイン前 header-->
-              <li><%= link_to "About", about_path, class: 'nav-link' %></li>
-              <li><%= link_to "商品一覧", items_path, class: 'nav-link' %></li>
-              <li><%= link_to "新規登録", new_customer_registration_path, class: 'nav-link' %></li>
-              <li><%= link_to "ログイン", new_customer_session_path, class: 'nav-link' %></li>
-            <% end %>
-          </ul>
+    <div class="container">
+      <div class="row w-100">
+        <div class="col-3">
+          <%= link_to root_path, class: 'nav-link nav-brand' do %>
+            <span>LOGO</span>
+          <% end %>
         </div>
-      </div>
-      <div class="row justify-content-end">
-        <%= form_with url: "#",class: "form-inline" do |f| %>
-          <%= f.text_field :search, class: "form-control"%>
-          <%= f.submit "検索", class: "btn btn-outline-success"%>
-        <% end %>
+        <div class="col-9">
+          <div class="row w-100 justify-content-end">
+            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+              <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse justify-content-end" id="navbarNavDropdown">
+              <ul class="navbar-nav ml-5">
+                <% if customer_signed_in? %>
+                  <!--Customer ログイン後header-->
+                  <span class="navbar-text text-right">ようこそ、<%= current_customer.full_name %>さん</span>
+                  <li><%= link_to "マイページ", customers_path,                class: 'nav-link text-right' %></li>
+                  <li><%= link_to "商品一覧",   items_path,                    class: 'nav-link text-right' %></li>
+                  <li><%= link_to "カート",     cart_items_path,               class: 'nav-link text-right' %></li>
+                  <li><%= link_to "ログアウト", destroy_customer_session_path, class: 'nav-link text-right', method: :delete %></li>
+                <% elsif admin_signed_in? %>
+                  <!--Admin ログイン後header-->
+                  <li><%= link_to "商品一覧",     admin_items_path,           class: 'nav-link text-right' %></li>
+                  <li><%= link_to "会員一覧",     admin_customers_path,       class: 'nav-link text-right' %></li>
+                  <li><%= link_to "注文履歴一覧", admin_path,                 class: 'nav-link text-right' %></li>
+                  <li><%= link_to "ジャンル一覧", admin_genres_path,          class: 'nav-link text-right' %></li>
+                  <li><%= link_to "ログアウト",   destroy_admin_session_path, class: 'nav-link text-right', method: :delete %></li>
+                <% else %>
+                  <!--共通ログイン前 header-->
+                  <li><%= link_to "About",    about_path,                     class: 'nav-link text-right' %></li>
+                  <li><%= link_to "商品一覧", items_path,                     class: 'nav-link text-right' %></li>
+                  <li><%= link_to "新規登録", new_customer_registration_path, class: 'nav-link text-right' %></li>
+                  <li><%= link_to "ログイン", new_customer_session_path,      class: 'nav-link text-right' %></li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+          <div class="row mt-2 w-100 justify-content-end">
+            <%= form_with url: "#",class: "form-inline" do |f| %>
+              <%= f.text_field :search, class: "form-control"%>
+              <%= f.submit "検索", class: "btn btn-outline-success"%>
+            <% end %>
+          </div>
+        </div>
       </div>
     </div>
   </nav>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -19,29 +19,25 @@
       <!--商品群-->
       <div class="h2 font-weight-bold mt-4">新着商品</div>
       <div class="items d-flex mx-4">
-
         <!--１つの行に４商品を表示する-->
         <div class="row">
           <% @items.each do |item| %>
-
             <!--１商品-->
             <div class="col-3 mt-3", style="padding-left: 0px">
               <%= link_to item_path(item.id) do %>
-                <%= image_tag item.get_image(180, 180) %>
+                <div class="d-flex align-items-center" style="width: 180px; height: 180px;">
+                  <%= image_tag item.get_image(180, 180) %>
+                </div>
               <% end %><br>
               <b><%= item.name %></b><br>
               <b>¥<%= number_with_delimiter(item.price) %></b>
             </div>
-
           <% end %>
         </div>
-
       </div>
-
       <div class="mt-3 text-right">
         <%= link_to "全ての商品を見る >", items_path %>
       </div>
-
     </div>
 
   </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -23,7 +23,7 @@
           該当する商品はありません
         <% else %>
           <!--１つの行に４商品を表示する-->
-          <div class="row">
+          <div class="row w-100">
             <% @items.each do |item| %>
 
               <!--１商品-->

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -29,7 +29,9 @@
               <!--１商品-->
               <div class="col-3 mt-3", style="padding-left: 0px">
                 <%= link_to item_path(item.id) do %>
-                  <%= image_tag item.get_image(180, 180) %>
+                  <div class="d-flex align-items-center" style="width: 180px; height: 180px;">
+                    <%= image_tag item.get_image(180, 180) %>
+                  </div>
                 <% end %><br>
                 <b><%= item.name %></b><br>
                 <b>¥<%= number_with_delimiter(item.price) %></b>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container my-5">
   <div class="row">
-    <div class="col-9 mx-auto">
+    <div class="col-9 mx-auto mb-4">
       <h5 class="font-weight-bold"><span class="bg-light px-4">注文履歴一覧</span></h5>
     </div>
   </div>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -12,20 +12,24 @@
         <table class="table">
           <tbody>
             <tr>
-              <td>注文日</td>
-              <td><%= @order.created_at.strftime("%Y/%m/%d") %></td>
+              <td class="pl-5">注文日</td>
+              <td><%= l @order.created_at, format: :short %></td>
             </tr>
             <tr>
-              <td>配送先</td>
+              <td class="pl-5">配送先</td>
               <td><%= '〒' + @order.postal_code %><br><%= @order.address %><br><%= @order.name %></td>
             </tr>
             <tr>
-              <td>支払方法</td>
+              <td class="pl-5">支払方法</td>
               <td><%= Order.payment_methods_i18n[@order.payment_method] %></td>
             </tr>
             <tr>
-              <td>ステータス</td>
+              <td class="pl-5">ステータス</td>
               <td><%= Order.statuses_i18n[@order.status] %></td>
+            </tr>
+            <tr>
+              <td width=30%></td>
+              <td width=70%></td>
             </tr>
           </tbody>
         </table>
@@ -38,15 +42,15 @@
         <tbody>
           <tr>
             <td>商品合計</td>
-            <td><%= (@order.total_cost-@order.shipping_cost).to_s(:delimited) %></td>
+            <td class="text-right pr-5"><%= (@order.total_cost-@order.shipping_cost).to_s(:delimited) %></td>
           </tr>
           <tr>
             <td>配送料</td>
-            <td><%= @order.shipping_cost.to_s(:delimited) %></td>
+            <td class="text-right pr-5"><%= @order.shipping_cost.to_s(:delimited) %></td>
           </tr>
           <tr>
             <td><b>ご請求額</b></td>
-            <td><%= @order.total_cost.to_s(:delimited) %></td>
+            <td class="text-right pr-5"><%= @order.total_cost.to_s(:delimited) %></td>
           </tr>
         </tbody>
       </table>
@@ -66,10 +70,10 @@
         <tbody>
           <% @order.order_details.each do |order_detail| %>
             <tr>
-              <td><%= order_detail.item.name %></td>
-              <td><%= order_detail.price.to_s(:delimited) %></td>
-              <td><%= order_detail.quantity.to_s(:delimited) %></td>
-              <td><%= order_detail.sub_total.to_s(:delimited) %></td>
+              <td class="pl-5"><%= order_detail.item.name %></td>
+              <td class="text-right pr-5"><%= order_detail.price.to_s(:delimited) %></td>
+              <td class="text-right pr-5"><%= order_detail.quantity.to_s(:delimited) %></td>
+              <td class="text-right pr-5"><%= order_detail.sub_total.to_s(:delimited) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,23 +2,24 @@
     enums:
       order:
         payment_method:
-          transfer: "銀行振込"
+          transfer:    "銀行振込"
           credit_card: "クレジットカード"
         status:
           waiting_for_payment: "入金待ち"
-          confirm_payment: "入金確認"
-          making_products: "製作中"
-          packaging_products: "発送準備中"
-          shipped_products: "発送済み"
+          confirm_payment:     "入金確認"
+          making_products:     "製作中"
+          packaging_products:  "発送準備中"
+          shipped_products:    "発送済み"
       order_detail:
         making_status:
-          can_not_start: "着手不可"
-          waiting_for_making: "製作待ち"
-          process_in_making: "製作中"
-          finished_making: "製作完了"
+          can_not_start:       "着手不可"
+          waiting_for_making:  "製作待ち"
+          process_in_making:   "製作中"
+          finished_making:     "製作完了"
     time:
       formats:
         default: "%Y/%m/%d %H:%M:%S"
+        short:   "%Y/%m/%d"
     activerecord:
       attributes:
         customer:


### PR DESCRIPTION
# headerのレシポンシブ対応
- container
 - col-3 ロゴ画像用
 - col-9 リンク+検索アイテム用
  - row リンクリスト ↔ ドロップダウンリスト
  - row 検索窓
の構成で再構築

# 商品一覧最終ページ表示
## rowにw-100追加で解決
## 画像表示用に180x180のdivを用意し、水平配置するように設定、全体にlinkを設定
```
<%= link_to item_path(item.id) do %>
  <div class="d-flex align-items-center" style="width: 180px; height: 180px;">
    <%= image_tag item.get_image(180, 180) %>
  </div>
<% end %><br>
```

# 前に外したprocessedを復活した。速くなった。
```
image.variant(resize_to_limit: [width, height])
> \> image.variant(resize_to_limit: [width, height]).processed
```

# 注文履歴タイトルマージン
class に mb-4　を追加し、ページタイトル部に下部マージンを設定

# 注文情報入力エラーフラッシュ変更
# 注文履歴詳細金額右揃え
# カート個数変更時フラッシュメッセージ