### PR TITLE
[Update] genresテーブル内is_activeカラムとitemsテーブルの連動

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -32,7 +32,7 @@ class Admin::GenresController < ApplicationController
   private
 
   def genre_params
-    params.require(:genre).permit(:name)
+    params.require(:genre).permit(:name, :is_active)
   end
 
 end

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,7 +1,7 @@
 class Public::HomesController < ApplicationController
   def top
-    @items = Item.all.order(id: "DESC").limit(4)
-    @genres = Genre.all
+    @items = Item.joins(:genre).where(genre: { is_active: true }, is_active: true).order(id: "DESC").limit(4)
+    @genres = Genre.where(is_active: true)
   end
 
   def about

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -2,11 +2,11 @@ class Public::ItemsController < ApplicationController
   def index
     if params[:genre_id]
       @genre = Genre.find(params[:genre_id])
-      @items = Item.where(genre_id: params[:genre_id], is_active: true).page(params[:page]).per(8).order(id: "DESC")
+      @items = Item.joins(:genre).where(genre: { is_active: true }, genre_id: params[:genre_id], is_active: true).order(id: "DESC").page(params[:page]).per(8)
     else
-      @items = Item.where(is_active: true).page(params[:page]).per(8).order(id: "DESC")
+      @items = Item.joins(:genre).where(genre: { is_active: true }, is_active: true).order(id: "DESC").page(params[:page]).per(8)
     end
-    @genres = Genre.all
+    @genres = Genre.where(is_active: true)
   end
 
   def show

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -4,4 +4,12 @@ class Genre < ApplicationRecord
 
   validates :name, presence: true
 
+  after_update :update_item_is_active, if: :saved_change_to_is_active?
+
+  def update_item_is_active
+    if self.is_active == false
+      self.items.update_all(is_active: false)
+    end
+  end
+
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -15,6 +15,15 @@
           <tr>
             <td class="align-middle">ジャンル名</td>
             <td><%= f.text_field :name, placeholder: "ジャンル名", class:"form-control" %></td>
+          <tr>
+            <td>ステータス</td>
+              <td>
+                <%= f.radio_button :is_active, true, checked: true %>
+                <%= label_tag :is_active_true, "有効" %>
+                <%= f.radio_button :is_active, false, class: "ml-3" %>
+                <%= label_tag :is_active_false, "無効" %>
+              </td>
+            </tr>
             <td><%= f.submit "変更を保存", class:"btn btn-block btn-success font-weight-bold ml-3" %></td>
           </tr>
         </table>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -2,10 +2,10 @@
   <div class="row">
 
     <div class="col-7">
-      
+
       <!--エラーメッセージ-->
       <%= render 'layouts/errors', obj: @genre %>
-      
+
       <h5 class="font-weight-bold ml-5 mb-3"><span class="bg-light px-4">ジャンル一覧・追加</span></h5>
 
       <!--ジャンル新規登録欄-->
@@ -20,10 +20,11 @@
       <% end %>
 
         <!--ジャンル一覧-->
-        <div class="col-9">
+        <div class="col-11">
           <table class="table">
             <thead class="bg-light">
               <th class="text-center">ジャンル</th>
+              <th class="text-center">ステータス</th>
               <th></th>
             </thead>
 
@@ -31,6 +32,13 @@
               <% @genres.each do |genre| %>
                 <tr>
                   <td class="align-middle"><%= genre.name %></td>
+                  <td class="align-middle text-center">
+                    <% if genre.is_active %>
+                      <span style="color: green;">有効</span>
+                    <% else %>
+                      <span style="color: gray;">無効</span>
+                    <% end %>
+                  </td>
                   <td><%= link_to "編集する", edit_admin_genre_path(genre), class:"col-7 offset-3 btn btn-success font-weignt-bold" %></td>
                 </tr>
               <% end %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -20,7 +20,7 @@
       <div class="h2 font-weight-bold mt-4">新着商品</div>
       <div class="items d-flex mx-4">
         <!--１つの行に４商品を表示する-->
-        <div class="row">
+        <div class="row w-100">
           <% @items.each do |item| %>
             <!--１商品-->
             <div class="col-3 mt-3", style="padding-left: 0px">

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -20,7 +20,7 @@
       <div class="items d-flex ml-4">
 
         <% if @items.empty? %>
-          該当する商品はありません
+          <p class="mt-4">該当する商品はありません</p>
         <% else %>
           <!--１つの行に４商品を表示する-->
           <div class="row w-100">

--- a/db/migrate/20230522124436_add_is_active_to_genres.rb
+++ b/db/migrate/20230522124436_add_is_active_to_genres.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToGenres < ActiveRecord::Migration[6.1]
+  def change
+    add_column :genres, :is_active, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_15_065241) do
+ActiveRecord::Schema.define(version: 2023_05_22_124436) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2023_05_15_065241) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_active", default: true, null: false
   end
 
   create_table "items", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,10 +54,22 @@ Address.create!(
 
 Genre.create!(
   [
-    {name: "ケーキ"},
-    {name: "焼き菓子"},
-    {name: "プリン"},
-    {name: "キャンディ"}
+    {
+      name: "ケーキ",
+      is_active: true
+    },
+    {
+      name: "焼き菓子",
+      is_active: true
+    },
+    {
+      name: "プリン",
+      is_active: true
+    },
+    {
+      name: "キャンディ",
+      is_active: true
+    }
   ]
 )
 


### PR DESCRIPTION
seed.rbにgenresのis_activeカラムの情報を追記してあるので再度、rails db:seedをお願いします

## admin/genres
- is_activeカラムの追加（デフォルトはtrue）
- 送られたis_activeデータを受け入れるためのストロングパラメータ内への追記
- genresモデル内にitemsとのステータス連動（販売中⇨販売停止のみ）を行う、update_item_is_activeメソッドの作成
- indexビュー（ジャンル一覧）にis_activeステータス状態を表示し、レイアウト調整
- editビュー（ジャンル編集）にis_activeステータス状態の変更欄を表示し、レイアウト調整

## db/seeds
- genres配下へのis_activeカラムの追加に伴った初期データの追記

## public/homes, public/items共通
- genreのステータスが無効である場合、サイドバーに表示させない記述を追加
- itemのステータスと、itemに紐づいたgenreのステータスがどちらも有効になっている場合のみ、商品が一覧に表示される記述を追加
タグが無効のまま商品だけを有効化しても、フロント側の一覧画面には表示されない。
タグごと無効にした商品を再度表示させる場合は、以下の手順を踏む。
①タグを有効化
②タグに紐づいた商品の有効化

## public/homes
- Topページ新着一覧内で、登録された商品が4つ未満の際の表示が崩れないようにするための記述を追加

## public/items
- 商品を一つも登録していない際にindexビュー（商品一覧）に表示される「該当する商品はありません」にmt-4を追加