### PR TITLE
[Update] 画像ファイル選択時のプレビュー機能追加

### DIFF
--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -13,7 +13,11 @@
           <table class="table table-borderless">
             <tr>
               <td>商品画像</td>
-              <td><%= f.file_field :image, accept: "image/png, image/jpeg" %></td>
+              <td>
+                <%= f.file_field :image, accept: "image/png, image/jpeg" %><br>
+                <!--プレビュー表示-->
+                <img class="mt-2" id="image-preview" src="#" alt="プレビュー" style="max-width: 150px; border: solid thin lightgray; border-radius: 5px;">
+              </td>
             </tr>
             <tr>
               <td>商品名</td>
@@ -51,3 +55,31 @@
     </div>
   </div>
 </div>
+
+<!--画像ファイルが選択された際に発火し、画像のプレビューを表示-->
+<script>
+  // 初期状態では非表示に
+  $("#image-preview").hide();
+
+  // 画像が選択された際に実行される関数
+  function showPreview(event) {
+    var file = event.target.files[0];
+    var reader = new FileReader();
+
+    // アップロードした画像をセットし、表示する
+    reader.onload = function(e) {
+      var previewElement = $("#image-preview");
+      previewElement.attr("src", e.target.result);
+      previewElement.show(); // 画像を表示する
+    }
+
+    // ファイルをデータURL形式で読み込む
+    if (file) {
+      reader.readAsDataURL(file);
+    }
+  }
+
+  // 再度別画像が読み込まれた時にプレビューを変更する
+  var fileInput = $("#item_image");
+  fileInput.on("change", showPreview);
+</script>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -9,14 +9,14 @@
 
       <!--ジャンル新規登録欄（ポップアップ表示）-->
       <div class="col-8 mx-auto form-group" id="new-genre-form"
-           style="display: none; position: absolute; top: 32%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0, 0, 0, 0.6); padding: 35px; z-index: 9999;">
+           style="display: none; position: absolute; top: 30%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0, 0, 0, 0.6); padding: 30px; z-index: 9999;">
         <table class="table table-borderless">
             <tr>
               <td>
-                <%= form_with model: @genre, url: admin_genres_path do |f| %>
-                  <%= f.text_field :name, placeholder: "新規ジャンル名", class: "form-control" %><br>
-                  <p class="text-white"> ※作成をやめる場合、以下のジャンルをお選びください</p>
-                  <%= f.submit "ジャンル作成", class:"btn btn-primary" %>
+                <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
+                  <%= f.text_field :name, placeholder: "新規ジャンル名", class: "form-control mr-2", style: "width: 70%" %>
+                  <%= f.submit "ジャンル作成", class:"btn btn-primary", style: "width: 25%" %><br>
+                  <p class="text-white pt-3"> ※作成をやめる場合、以下より再度ジャンルをお選びください</p>
                 <% end %>
               </td>
             </tr>
@@ -29,7 +29,11 @@
           <table class="table table-borderless">
             <tr>
               <td>商品画像</td>
-              <td><%= f.file_field :image, accept: "image/png, image/jpeg" %></td>
+              <td>
+                <%= f.file_field :image, accept: "image/png, image/jpeg" %><br>
+                <!--プレビュー表示-->
+                <img class="mt-2" id="image-preview" src="#" alt="プレビュー" style="max-width: 150px; border: solid thin lightgray; border-radius: 5px;">
+              </td>
             </tr>
             <tr>
               <td>商品名</td>
@@ -73,10 +77,12 @@
 
 <!--「新しくジャンルを作成する」の選択時に発火-->
 <script>
+  // HTMLドキュメントが読み込まれた後に実行される関数
   $(document).ready(function() {
     var genreSelect = $("#genre-select");
     var newGenreForm = $("#new-genre-form");
 
+    // ジャンル選択の内容がチェンジされたときに実行する処理
     genreSelect.on("change", function() {
       if (genreSelect.val() === "new") {
         slideDown(newGenreForm);
@@ -85,12 +91,42 @@
       }
     });
 
+    // 引数で指定された要素をスライドダウンさせる処理
     function slideDown(element) {
       element.fadeIn(300);
     }
 
+    //引数で指定された要素をスライドアップさせる処理
     function slideUp(element) {
       element.fadeOut(300);
     }
   });
+</script>
+
+<!--画像ファイルが選択された際に発火し、画像のプレビューを表示-->
+<script>
+  // 初期状態では非表示に
+  $("#image-preview").hide();
+
+  // 画像が選択された際に実行される関数
+  function showPreview(event) {
+    var file = event.target.files[0];
+    var reader = new FileReader();
+
+    // アップロードした画像をセットし、表示する
+    reader.onload = function(e) {
+      var previewElement = $("#image-preview");
+      previewElement.attr("src", e.target.result);
+      previewElement.show(); // 画像を表示する
+    }
+
+    // ファイルをデータURL形式で読み込む
+    if (file) {
+      reader.readAsDataURL(file);
+    }
+  }
+
+  // 再度別画像が読み込まれた時にプレビューを変更する
+  var fileInput = $("#item_image");
+  fileInput.on("change", showPreview);
 </script>


### PR DESCRIPTION
## 変更箇所
- admin/items/new.html.erb
- admin/items/edit.html.erb

## 変更概要
- admin側での新規商品登録及び商品編集画面内にてアップロードする画像を選択した際の画像プレビュー表示の追加

## 商品画像選択フォーム内のコードを変更
変更前
```
<td> <%= f.file_field :image, accept: "image/png, image/jpeg" %></td>
```

変更後
```ruby
<td>
<%= f.file_field :image, accept: "image/png, image/jpeg" %><br>
<!--プレビュー表示-->
<img class="mt-2" id="image-preview" src="#" alt="プレビュー" style="max-width: 150px; border: solid thin lightgray; border-radius: 5px;">
</td>
```

## 動作確認
- [x] プレビューで表示された画像が問題なく商品画像として登録されている
- [x] 画像を選択したあと再び別画像を選択した際に、プレビュー内の画像が問題なく切り替わっている

## 補足情報
- scriptタグ内にコメントアウトで各処理の説明を追加
- admin/items/new.html.erbにて、ジャンル新規登録欄（ポップアップ表示）内のレイアウトや文言を調整